### PR TITLE
Added analyze parameter

### DIFF
--- a/parceler-api/src/main/java/org/parceler/Parcel.java
+++ b/parceler-api/src/main/java/org/parceler/Parcel.java
@@ -66,6 +66,10 @@ public @interface Parcel {
 
     boolean parcelsIndex() default true;
 
+    Class[] analyze() default {};
+
+    Class<? extends ParcelConverter> converter() default ParcelConverter.EmptyConverter.class;
+
     enum Serialization {
         FIELD,
         /**
@@ -75,9 +79,4 @@ public @interface Parcel {
         METHOD,
         BEAN
     }
-
-    /**
-     * Optional Converter class.
-     */
-    Class<? extends ParcelConverter> converter() default ParcelConverter.EmptyConverter.class;
 }

--- a/parceler/src/main/java/org/parceler/internal/ASTTypeHierarchyIterator.java
+++ b/parceler/src/main/java/org/parceler/internal/ASTTypeHierarchyIterator.java
@@ -1,0 +1,64 @@
+package org.parceler.internal;
+
+import com.google.common.collect.ImmutableSet;
+import org.androidtransfuse.adapter.ASTType;
+
+import java.util.Iterator;
+
+/**
+ * @author John Ericksen
+ */
+public class ASTTypeHierarchyIterator implements Iterator<ASTType> {
+
+    private final ImmutableSet<ASTType> analyze;
+    private final ASTType root;
+
+    private ASTType current;
+    private boolean started;
+
+    public ASTTypeHierarchyIterator(ASTType root, ImmutableSet<ASTType> analyze) {
+        this.root = root;
+        this.analyze = analyze;
+    }
+
+    @Override
+    public boolean hasNext() {
+        return calculateNext() != null;
+    }
+
+    @Override
+    public ASTType next() {
+        current = calculateNext();
+        if(!started){
+            started = true;
+        }
+        return current;
+    }
+
+    protected ASTType calculateNext(){
+        ASTType next = null;
+        if(current == null){
+            if(!started) {
+                next = root;
+            }
+        }
+        else{
+            next = current.getSuperClass();
+        }
+
+        while(next != null && !checkAnalysis(next)){
+            next = next.getSuperClass();
+        }
+
+        return next;
+    }
+
+    private boolean checkAnalysis(ASTType type){
+        return analyze.isEmpty() || analyze.contains(type);
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/parceler/src/test/java/org/parceler/internal/ASTTypeHierarchyIteratorTest.java
+++ b/parceler/src/test/java/org/parceler/internal/ASTTypeHierarchyIteratorTest.java
@@ -1,0 +1,79 @@
+package org.parceler.internal;
+
+import com.google.common.collect.ImmutableSet;
+import org.androidtransfuse.adapter.ASTType;
+import org.androidtransfuse.adapter.classes.ASTClassFactory;
+import org.androidtransfuse.bootstrap.Bootstrap;
+import org.androidtransfuse.bootstrap.Bootstraps;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.inject.Inject;
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+@Bootstrap
+public class ASTTypeHierarchyIteratorTest {
+
+    static class A extends B{}
+    static class B extends C{}
+    static class C {}
+
+    private ASTType a;
+    private ASTType b;
+    private ASTType c;
+    private ASTType object;
+
+    @Inject
+    ASTClassFactory astClassFactory;
+
+    @Before
+    public void setup(){
+        Bootstraps.inject(this);
+        a = astClassFactory.getType(A.class);
+        b = astClassFactory.getType(B.class);
+        c = astClassFactory.getType(C.class);
+        object = astClassFactory.getType(Object.class);
+    }
+
+    @Test
+    public void testRegularIterator(){
+        Iterator<ASTType> iterator = new ASTTypeHierarchyIterator(a, ImmutableSet.<ASTType>of());
+
+        assertTrue(iterator.hasNext());
+        assertEquals(a, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(b, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(c, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(object, iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals(null, iterator.next());
+    }
+
+    @Test
+    public void testSkipIterator(){
+        Iterator<ASTType> iterator = new ASTTypeHierarchyIterator(a, ImmutableSet.<ASTType>of(b, c));
+
+        assertTrue(iterator.hasNext());
+        assertEquals(b, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(c, iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals(null, iterator.next());
+    }
+
+    @Test
+    public void testSkipIncludingObjectIterator(){
+        Iterator<ASTType> iterator = new ASTTypeHierarchyIterator(a, ImmutableSet.<ASTType>of(c, object));
+
+        assertTrue(iterator.hasNext());
+        assertEquals(c, iterator.next());
+        assertTrue(iterator.hasNext());
+        assertEquals(object, iterator.next());
+        assertFalse(iterator.hasNext());
+        assertEquals(null, iterator.next());
+    }
+}


### PR DESCRIPTION
This property specifies what classes for Parceler analyze in the class hierarchy.

Usage:

```java
class A { String analyzed1; }
class B extends A { String notAnalyzed; }
@Parcel(analyzed = {A.class, C.class})
class C extends B { String analyzed2; }
```

This would result in the contents of A and C being serialized, skipping B's contents.