### PR TITLE
change README to support the new android studio DSL

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -431,7 +431,7 @@ or Gradle:
 [source,groovy]
 ----
 compile "org.parceler:parceler-api:${parcelerVersion}"
-apt "org.parceler:parceler:${parcelerVersion}"
+provided "org.parceler:parceler:${parcelerVersion}"
 ----
 
 Or from http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.parceler%22[Maven Central].

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -428,10 +428,27 @@ You may download Parceler as a Maven dependency:
 ----
 
 or Gradle:
+
+Add the following classpath to your top-level build.gradle file
+
+[source,groovy]
+----
+classpath 'com.neenbedankt.gradle.plugins:android-apt:${androidaptVersion}'
+----
+
+Apply the plugin in your app/build.gradle file
+
+[source,groovy]
+----
+apply plugin: 'com.neenbedankt.android-apt'
+----
+
+Mention dependency in app/build.gradle file
+
 [source,groovy]
 ----
 compile "org.parceler:parceler-api:${parcelerVersion}"
-provided "org.parceler:parceler:${parcelerVersion}"
+apt "org.parceler:parceler:${parcelerVersion}"
 ----
 
 Or from http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.parceler%22[Maven Central].


### PR DESCRIPTION
Using the following does not work in the latest android studio anymore. The new DSL expects the word to be provided instead of apt

```
compile "org.parceler:parceler-api:1.0.3"
apt "org.parceler:parceler:1.0.3"
```
So, this is the one that worked for me.

```
compile "org.parceler:parceler-api:1.0.3"
provided "org.parceler:parceler:1.0.3"
```

Please point out if I am missing out any point.
Thanks
