### PR TITLE
Added identity collections during build to avoid instance loops

### DIFF
--- a/examples/test/src/test/java/org/parceler/CircularReferenceTest.java
+++ b/examples/test/src/test/java/org/parceler/CircularReferenceTest.java
@@ -23,6 +23,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author John Ericksen
@@ -46,9 +47,7 @@ public class CircularReferenceTest {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof One)) return false;
-
             One one = (One) o;
-
             return EqualsBuilder.reflectionEquals(this, one);
         }
 
@@ -73,9 +72,7 @@ public class CircularReferenceTest {
         public boolean equals(Object o) {
             if (this == o) return true;
             if (!(o instanceof Two)) return false;
-
             Two two = (Two) o;
-
             return EqualsBuilder.reflectionEquals(this, two);
         }
 
@@ -97,5 +94,251 @@ public class CircularReferenceTest {
         One unwrap = Parcels.unwrap(ParcelsTestUtil.wrap(target));
 
         assertEquals(target, unwrap);
+    }
+
+    @Parcel
+    static class Three {
+        Four four;
+        String name;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Three)) return false;
+            Three three = (Three) o;
+            return EqualsBuilder.reflectionEquals(this, three, new String[]{"four"});
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this, new String[]{"four"});
+        }
+    }
+
+    @Parcel
+    static class Four {
+        Three three;
+        String name;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Three)) return false;
+            Four four = (Four) o;
+            return EqualsBuilder.reflectionEquals(this, four, new String[]{"three"});
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this, new String[]{"three"});
+        }
+    }
+
+    @Test
+    public void testCircularInstances() {
+        Three three = new Three();
+        Four four = new Four();
+
+        three.name = "3";
+        four.name = "4";
+
+        three.four = four;
+        four.three = three;
+
+        Three unwrap = Parcels.unwrap(ParcelsTestUtil.wrap(three));
+
+        assertEquals(three, unwrap);
+        assertEquals(four, three.four);
+    }
+
+    @Parcel
+    static class Five {
+        Six a;
+        Six b;
+        Six c;
+        String name;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Five)) return false;
+            Five five = (Five) o;
+            return EqualsBuilder.reflectionEquals(this, five, new String[]{"a", "b", "c"});
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this, new String[]{"a", "b", "c"});
+        }
+    }
+
+    @Parcel
+    static class Six{
+        String name;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Six)) return false;
+            Six six = (Six) o;
+            return EqualsBuilder.reflectionEquals(this, six);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+    }
+
+    @Test
+    public void testMultipleReferences() {
+        Five five = new Five();
+        five.name = "5";
+        Six six = new Six();
+        five.a = six;
+        five.b = six;
+        five.c = six;
+        six.name = "6";
+
+        Five unwrap = Parcels.unwrap(ParcelsTestUtil.wrap(five));
+
+        assertEquals(five, unwrap);
+        assertEquals(five.a, unwrap.a);
+        assertEquals(five.b, unwrap.b);
+        assertEquals(five.c, unwrap.c);
+        assertEquals(unwrap.a, unwrap.b);
+        assertEquals(unwrap.a, unwrap.c);
+    }
+
+    @Parcel
+    static class Seven {
+        Eight eight;
+        String name;
+        @ParcelConstructor Seven(Eight eight, String name){
+            this.eight = eight;
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Seven)) return false;
+            Seven seven = (Seven) o;
+            return EqualsBuilder.reflectionEquals(this, seven);
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this);
+        }
+    }
+
+    @Parcel
+    static class Eight {
+        Seven seven;
+        String name;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Eight)) return false;
+            Eight eight = (Eight) o;
+            return EqualsBuilder.reflectionEquals(this, eight, new String[]{"seven"});
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this, new String[]{"seven"});
+        }
+    }
+
+    @Test
+    public void testCircularConstructor(){
+        Eight eight = new Eight();
+        eight.name = "8";
+        Seven seven = new Seven(eight, "7");
+        eight.seven = seven;
+
+        Eight unwrappedEight = Parcels.unwrap(ParcelsTestUtil.wrap(eight));
+
+        assertEquals(eight, unwrappedEight);
+        assertEquals(seven, unwrappedEight.seven);
+        assertEquals(eight, unwrappedEight.seven.eight);
+
+        try {
+            Parcels.unwrap(ParcelsTestUtil.wrap(seven));
+            assertTrue("Parcels.unwrap did not throw an exception", false);
+        }
+        catch (ParcelerRuntimeException e){}
+    }
+
+    @Parcel
+    static class Nine {
+        Ten ten;
+        String name;
+
+        public Nine(Ten ten, String name) {
+            this.ten = ten;
+            this.name = name;
+        }
+
+        @ParcelFactory
+        public static Nine build(Ten ten, String name){
+            return new Nine(ten, name);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Nine)) return false;
+            Nine nine = (Nine) o;
+            return EqualsBuilder.reflectionEquals(this, nine, new String[]{"ten"});
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this, new String[]{"ten"});
+        }
+    }
+
+    @Parcel
+    static class Ten {
+        Nine nine;
+        String name;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Ten)) return false;
+
+            Ten ten = (Ten) o;
+
+            return EqualsBuilder.reflectionEquals(this, ten, new String[]{"nine"});
+        }
+
+        @Override
+        public int hashCode() {
+            return HashCodeBuilder.reflectionHashCode(this, new String[]{"nine"});
+        }
+    }
+
+    @Test
+    public void testCircularFactory(){
+        Ten ten = new Ten();
+        ten.name = "10";
+        Nine nine = Nine.build(ten, "9");
+        ten.nine = nine;
+
+        Ten unwrappedTen = Parcels.unwrap(ParcelsTestUtil.wrap(ten));
+
+        assertEquals(ten, unwrappedTen);
+        assertEquals(ten, unwrappedTen.nine.ten);
+        assertEquals(nine, unwrappedTen.nine);
+
+        try {
+            Parcels.unwrap(ParcelsTestUtil.wrap(nine));
+            assertTrue("Parcels.unwrap did not throw an exception", false);
+        }
+        catch (ParcelerRuntimeException e){}
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/ArrayReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ArrayReadWriteGenerator.java
@@ -45,7 +45,7 @@ public class ArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
 
         if(!(type instanceof ASTArrayType)){
             throw new ParcelerRuntimeException("Input type not an array");
@@ -78,7 +78,7 @@ public class ArrayReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
 
         readLoopBody.assign(outputVar.component(nVar), readExpression);
 
@@ -86,7 +86,7 @@ public class ArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
 
         if(!(type instanceof ASTArrayType)){
             throw new ParcelerRuntimeException("Input type not an array");
@@ -108,6 +108,6 @@ public class ArrayReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        generator.generateWriter(forEach.body(), parcel, flags, componentType, forEach.var(), parcelableClass);
+        generator.generateWriter(forEach.body(), parcel, flags, componentType, forEach.var(), parcelableClass, writeIdentitySet);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/BooleanEntryReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/BooleanEntryReadWriteGenerator.java
@@ -27,13 +27,13 @@ public class BooleanEntryReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         //target.programmingRelated = (parcel.readInt() == 1);
         return parcelParam.invoke(getReadMethod()).eq(JExpr.lit(1));
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         //parcel.writeInt(skill$$0.programmingRelated ? 1 : 0);
         body.invoke(parcel, getWriteMethod()).arg(JOp.cond(getExpression, JExpr.lit(1), JExpr.lit(0)));
     }

--- a/parceler/src/main/java/org/parceler/internal/generator/BundleReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/BundleReadWriteGenerator.java
@@ -28,12 +28,12 @@ public class BundleReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         return JExpr.cast(returnJClassRef, parcelParam.invoke(getReadMethod()).arg(parcelableClass.dotclass().invoke("getClassLoader")));
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         body.invoke(parcel, getWriteMethod()).arg(getExpression);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/ConverterWrapperReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ConverterWrapperReadWriteGenerator.java
@@ -31,12 +31,12 @@ public class ConverterWrapperReadWriteGenerator implements ReadWriteGenerator {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         return JExpr._new(converter).invoke(ParcelConverter.CONVERT_FROM_PARCEL).arg(parcelParam);
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         body.invoke(JExpr._new(converter), ParcelConverter.CONVERT_TO_PARCEL).arg(getExpression).arg(parcel);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/EnumReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/EnumReadWriteGenerator.java
@@ -38,7 +38,7 @@ public class EnumReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         JClass enumRef = generationUtil.ref(Enum.class);
         JClass enumClassRef = generationUtil.ref(type);
         JClass stringRef = generationUtil.ref(String.class);
@@ -49,7 +49,7 @@ public class EnumReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         JClass enumClassRef = generationUtil.ref(type);
 
         JVar localVar = body.decl(enumClassRef, namer.generateName(enumClassRef), getExpression);

--- a/parceler/src/main/java/org/parceler/internal/generator/ListReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ListReadWriteGenerator.java
@@ -49,7 +49,7 @@ public class ListReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
 
         JClass arrayListType = generationUtil.ref(listType);
 
@@ -82,7 +82,7 @@ public class ListReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
 
         readLoopBody.invoke(outputVar, "add").arg(readExpression);
 
@@ -90,7 +90,7 @@ public class ListReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
 
         ASTType componentType = astClassFactory.getType(Object.class);
 
@@ -110,6 +110,6 @@ public class ListReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        generator.generateWriter(forEach.body(), parcel, flags, componentType, forEach.var(), parcelableClass);
+        generator.generateWriter(forEach.body(), parcel, flags, componentType, forEach.var(), parcelableClass, writeIdentitySet);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/MapReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/MapReadWriteGenerator.java
@@ -50,7 +50,7 @@ public class MapReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
 
         JClass hashMapType = generationUtil.ref(mapType);
 
@@ -91,10 +91,10 @@ public class MapReadWriteGenerator extends ReadWriteGeneratorBase {
         ReadWriteGenerator keyGenerator = generators.getGenerator(keyComponentType);
         ReadWriteGenerator valueGenerator = generators.getGenerator(valueComponentType);
 
-        JExpression readKeyExpression = keyGenerator.generateReader(readLoopBody, parcelParam, keyComponentType, generationUtil.ref(keyComponentType), parcelableClass);
+        JExpression readKeyExpression = keyGenerator.generateReader(readLoopBody, parcelParam, keyComponentType, generationUtil.ref(keyComponentType), parcelableClass, readIdentityMap);
         JVar keyVar = readLoopBody.decl(keyType, namer.generateName(keyComponentType), readKeyExpression);
 
-        JExpression readValueExpression = valueGenerator.generateReader(readLoopBody, parcelParam, valueComponentType, generationUtil.ref(valueComponentType), parcelableClass);
+        JExpression readValueExpression = valueGenerator.generateReader(readLoopBody, parcelParam, valueComponentType, generationUtil.ref(valueComponentType), parcelableClass, readIdentityMap);
         JVar valueVar = readLoopBody.decl(valueType, namer.generateName(valueComponentType), readValueExpression);
 
         readLoopBody.invoke(outputVar, "put").arg(keyVar).arg(valueVar);
@@ -103,7 +103,7 @@ public class MapReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
 
         ASTType keyComponentType = astClassFactory.getType(Object.class);
         ASTType valueComponentType = astClassFactory.getType(Object.class);
@@ -131,7 +131,7 @@ public class MapReadWriteGenerator extends ReadWriteGeneratorBase {
         ReadWriteGenerator keyGenerator = generators.getGenerator(keyComponentType);
         ReadWriteGenerator valueGenerator = generators.getGenerator(valueComponentType);
 
-        keyGenerator.generateWriter(forEach.body(), parcel, flags, keyComponentType, forEach.var().invoke("getKey"), parcelableClass);
-        valueGenerator.generateWriter(forEach.body(), parcel, flags, valueComponentType, forEach.var().invoke("getValue"), parcelableClass);
+        keyGenerator.generateWriter(forEach.body(), parcel, flags, keyComponentType, forEach.var().invoke("getKey"), parcelableClass, writeIdentitySet);
+        valueGenerator.generateWriter(forEach.body(), parcel, flags, valueComponentType, forEach.var().invoke("getValue"), parcelableClass, writeIdentitySet);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/NullCheckReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/NullCheckReadWriteGenerator.java
@@ -38,7 +38,7 @@ public abstract class NullCheckReadWriteGenerator implements ReadWriteGenerator 
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
 
         JVar sizeVar = body.decl(codeModel.INT, namer.generateName(codeModel.INT), parcelParam.invoke("readInt"));
 
@@ -52,13 +52,13 @@ public abstract class NullCheckReadWriteGenerator implements ReadWriteGenerator 
 
         JBlock nonNullBody = nullInputConditional._else();
 
-        nonNullBody.assign(value, getGenerator().generateReader(body, parcelParam, type, returnJClassRef, parcelableClass));
+        nonNullBody.assign(value, getGenerator().generateReader(body, parcelParam, type, returnJClassRef, parcelableClass, readIdentityMap));
 
         return value;
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
 
         JConditional nullConditional = body._if(getExpression.eq(JExpr._null()));
         nullConditional._then().invoke(parcel, "writeInt").arg(JExpr.lit(-1));
@@ -66,7 +66,7 @@ public abstract class NullCheckReadWriteGenerator implements ReadWriteGenerator 
         JBlock writeBody = nullConditional._else();
         writeBody.invoke(parcel, "writeInt").arg(JExpr.lit(1));
 
-        getGenerator().generateWriter(writeBody, parcel, flags, type, getExpression, parcelableClass);
+        getGenerator().generateWriter(writeBody, parcel, flags, type, getExpression, parcelableClass, writeIdentitySet);
     }
 
     protected abstract ReadWriteGenerator getGenerator();

--- a/parceler/src/main/java/org/parceler/internal/generator/ParcelableReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ParcelableReadWriteGenerator.java
@@ -28,12 +28,12 @@ public class ParcelableReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         return JExpr.cast(returnJClassRef, parcelParam.invoke(getReadMethod()).arg(parcelableClass.dotclass().invoke("getClassLoader")));
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         body.invoke(parcel, getWriteMethod()).arg(getExpression).arg(flags);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/ReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ReadWriteGenerator.java
@@ -23,7 +23,7 @@ import org.androidtransfuse.adapter.ASTType;
 */
 public interface ReadWriteGenerator {
 
-    JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass);
+    JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap);
 
-    void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass);
+    void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet);
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/SerializableReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SerializableReadWriteGenerator.java
@@ -30,12 +30,12 @@ public class SerializableReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         return JExpr.cast(returnJClassRef, parcelParam.invoke(getReadMethod()));
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         body.invoke(parcel, getWriteMethod()).arg(getExpression);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/SetReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SetReadWriteGenerator.java
@@ -50,7 +50,7 @@ public class SetReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
 
         JClass arrayListType = generationUtil.ref(setType);
 
@@ -83,7 +83,7 @@ public class SetReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
 
         readLoopBody.invoke(outputVar, "add").arg(readExpression);
 
@@ -91,7 +91,7 @@ public class SetReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
 
         ASTType componentType = astClassFactory.getType(Object.class);
 
@@ -111,6 +111,6 @@ public class SetReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        generator.generateWriter(forEach.body(), parcel, flags, componentType, forEach.var(), parcelableClass);
+        generator.generateWriter(forEach.body(), parcel, flags, componentType, forEach.var(), parcelableClass, writeIdentitySet);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/SimpleReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SimpleReadWriteGenerator.java
@@ -28,12 +28,12 @@ public class SimpleReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         return parcelParam.invoke(getReadMethod());
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         body.invoke(parcel, getWriteMethod()).arg(getExpression);
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/SingleEntryArrayReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SingleEntryArrayReadWriteGenerator.java
@@ -35,12 +35,12 @@ public class SingleEntryArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         return JExpr.component(parcelParam.invoke(getReadMethod()), JExpr.lit(0));
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         body.invoke(parcel, getWriteMethod()).arg(JExpr.newArray(codeModel._ref(writeMethodParam)).add(getExpression));
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/SparseArrayReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SparseArrayReadWriteGenerator.java
@@ -47,7 +47,7 @@ public class SparseArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
 
         JClass sparseArrayType = generationUtil.ref("android.util.SparseArray");
 
@@ -82,7 +82,7 @@ public class SparseArrayReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
 
         readLoopBody.invoke(outputVar, "append").arg(keyVar).arg(readExpression);
 
@@ -90,7 +90,7 @@ public class SparseArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass) {
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
 
         JClass sparseArrayType = generationUtil.ref("android.util.SparseArray");
         ASTType componentType = astClassFactory.getType(Object.class);
@@ -119,6 +119,6 @@ public class SparseArrayReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        generator.generateWriter(readLoopBody, parcel, flags, componentType, spareArrayVar.invoke("valueAt").arg(nVar), parcelableClass );
+        generator.generateWriter(readLoopBody, parcel, flags, componentType, spareArrayVar.invoke("valueAt").arg(nVar), parcelableClass, writeIdentitySet);
     }
 }


### PR DESCRIPTION
Addresses #66 and #76 by storing and checking an object identifier collection during serialization.  If an object is not found in the corresponding collection then it is either written to or read from the Parcel.  If it is found in the corresponding collection, we avoid writing it to the Parcel (we write the identifier instead) and read it from the collection instead.

This handles the following cases:
1: A loop in the instances:
```java
A a = new A();
B b = new B();
a.b = b;
b.a = a;
```
See Test: https://github.com/johncarl81/parceler/blob/graph_map/examples/test/src/test/java/org/parceler/CircularReferenceTest.java#L138

2: Objects referenced in multiple spots:

```java
Five five = new Five();
Six six = new Six();
five.a = six;
five.b = six;
five.c = six;
```
See Test: https://github.com/johncarl81/parceler/blob/graph_map/examples/test/src/test/java/org/parceler/CircularReferenceTest.java#L194

Worth noting, this does not handle cases of loops through `@ParcelConstructor` annotated constructors or `@ParcelFactory` annotated methods and an exception is thrown if this case is detected:

1: `@ParcelConstructor`:
```java
Eight eight = new Eight();
eight.name = "8";
Seven seven = new Seven(eight, "7"); // @ParcelConstructor
eight.seven = seven;

Parcels.unwrap(ParcelsTestUtil.wrap(seven)); // Throws exception

Eight unwrappedEight = Parcels.unwrap(ParcelsTestUtil.wrap(eight)); // Successful.
```
See Test: https://github.com/johncarl81/parceler/blob/graph_map/examples/test/src/test/java/org/parceler/CircularReferenceTest.java#L256

2: `@ParcelFactory`: 
```java
Ten ten = new Ten();
ten.name = "10";
Nine nine = Nine.build(ten, "9"); // @ParcelFactory
ten.nine = nine;

Parcels.unwrap(ParcelsTestUtil.wrap(nine)); // Throws exception

Ten unwrappedTen = Parcels.unwrap(ParcelsTestUtil.wrap(ten)); // Successful
```
See Test: https://github.com/johncarl81/parceler/blob/graph_map/examples/test/src/test/java/org/parceler/CircularReferenceTest.java#L326