### PR TITLE
Fix modifier order

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -12,7 +12,7 @@ http://www.developerphil.com/parcelable-vs-serializable/[Compared] with traditio
 There is a major flaw with Parcelables, however.
 Parcelables contain a ton of boilerplate code.
 To implement a Parcelable, you must mirror the `writeToParcel()` and `createFromParcel()` methods such that they read and write to the Parcel in the same order.
-Also, a Parcelable must define a `public final static Parcelable.Creator CREATOR` in order for the Android infrastructure to be able to leverage the serialization code.
+Also, a Parcelable must define a `public static final Parcelable.Creator CREATOR` in order for the Android infrastructure to be able to leverage the serialization code.
 
 Parceler is a code generation library that generates the Android Parcelable boilerplate source code.
 No longer do you have to implement the Parcelable interface, the `writeToParcel()` or `createFromParcel()` or the `public static final CREATOR`.


### PR DESCRIPTION
This changes the field modifier order as suggested in the [Java Language Specification].(http://docs.oracle.com/javase/specs/jls/se7/html/jls-8.html#jls-8.3.1).
It should be `public static final` vs. `public final static`.