### PR TITLE
Refactored core serialization into build methods

### DIFF
--- a/parceler/src/main/java/org/parceler/internal/ParcelableGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/ParcelableGenerator.java
@@ -27,8 +27,10 @@ import org.parceler.ParcelConverter;
 import org.parceler.ParcelWrapper;
 import org.parceler.Parcels;
 import org.parceler.internal.generator.ConverterWrapperReadWriteGenerator;
+import org.parceler.internal.generator.EnumReadWriteGenerator;
 import org.parceler.internal.generator.ParcelReadWriteGenerator;
 import org.parceler.internal.generator.ReadWriteGenerator;
+import org.parceler.internal.matcher.EnumMatcher;
 
 import javax.inject.Inject;
 import java.util.*;
@@ -53,6 +55,7 @@ public class ParcelableGenerator {
     private final WriteReferenceVisitor writeToParcelVisitor;
     private final InvocationBuilder invocationBuilder;
     private final Generators generators;
+    private final EnumReadWriteGenerator enumReadWriteGenerator;
     private final ParcelReadWriteGenerator parcelReadWriteGenerator;
 
 
@@ -65,7 +68,7 @@ public class ParcelableGenerator {
                                WriteReferenceVisitor writeToParcelVisitor,
                                InvocationBuilder invocationBuilder,
                                Generators generators,
-                               ParcelReadWriteGenerator parcelReadWriteGenerator) {
+                               EnumReadWriteGenerator enumReadWriteGenerator, ParcelReadWriteGenerator parcelReadWriteGenerator) {
         this.codeModel = codeModel;
         this.variableNamer = variableNamer;
         this.classNamer = classNamer;
@@ -74,6 +77,7 @@ public class ParcelableGenerator {
         this.writeToParcelVisitor = writeToParcelVisitor;
         this.invocationBuilder = invocationBuilder;
         this.generators = generators;
+        this.enumReadWriteGenerator = enumReadWriteGenerator;
         this.parcelReadWriteGenerator = parcelReadWriteGenerator;
     }
 
@@ -323,8 +327,8 @@ public class ParcelableGenerator {
     }
 
     private ReadWriteGenerator getRootReadWriteGenerator(ASTType type) {
-        if(generators.matches(type)){
-            return generators.getGenerator(type);
+        if(type.isEnum()){
+            return enumReadWriteGenerator;
         }
         else {
             return parcelReadWriteGenerator;

--- a/parceler/src/main/java/org/parceler/internal/ParcelableGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/ParcelableGenerator.java
@@ -388,7 +388,7 @@ public class ParcelableGenerator {
         JBlock buildBody = writeMethodBody._if(identityParam.invoke("contains").arg(identity).not())._then();
         buildBody.add(identityParam.invoke("add").arg(identity));
 
-        JConditional nullCondition = buildBody._if(parcelParam.eq(JExpr._null()));
+        JConditional nullCondition = buildBody._if(writeInputVar.eq(JExpr._null()));
         nullCondition._then().add(parcelParam.invoke("writeInt").arg(JExpr.lit(-1)));
         JBlock nonNullCondition = nullCondition._else();
         nonNullCondition.add(parcelParam.invoke("writeInt").arg(JExpr.lit(1)));

--- a/parceler/src/main/java/org/parceler/internal/ParcelerModule.java
+++ b/parceler/src/main/java/org/parceler/internal/ParcelerModule.java
@@ -200,7 +200,7 @@ public class ParcelerModule {
                                     JCodeModel codeModel,
                                     SerializableReadWriteGenerator serializableReadWriteGenerator,
                                     NullCheckFactory nullCheckFactory,
-                                    ParcelReadWriteGenerator parcelReadWriteGenerator,
+                                    LinkParcelReadWriteGenerator parcelReadWriteGenerator,
                                     EnumReadWriteGenerator enumReadWriteGenerator){
 
         return addGenerators(new Generators(astClassFactory), astClassFactory, generationUtil, externalParcelRepository, namer, codeModel, serializableReadWriteGenerator, nullCheckFactory, parcelReadWriteGenerator, enumReadWriteGenerator);
@@ -214,7 +214,8 @@ public class ParcelerModule {
                                            JCodeModel codeModel,
                                            SerializableReadWriteGenerator serializableReadWriteGenerator,
                                            NullCheckFactory nullCheckFactory,
-                                           ParcelReadWriteGenerator parcelReadWriteGenerator, EnumReadWriteGenerator enumReadWriteGenerator){
+                                           LinkParcelReadWriteGenerator parcelReadWriteGenerator,
+                                           EnumReadWriteGenerator enumReadWriteGenerator){
 
         generators.addPair(byte.class, "readByte", "writeByte");
         generators.addPair(Byte.class, nullCheckFactory.get(Byte.class, generators, byte.class));

--- a/parceler/src/main/java/org/parceler/internal/generator/ArrayReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ArrayReadWriteGenerator.java
@@ -45,7 +45,7 @@ public class ArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
 
         if(!(type instanceof ASTArrayType)){
             throw new ParcelerRuntimeException("Input type not an array");
@@ -78,7 +78,7 @@ public class ArrayReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, identity, readIdentityMap);
 
         readLoopBody.assign(outputVar.component(nVar), readExpression);
 

--- a/parceler/src/main/java/org/parceler/internal/generator/BooleanEntryReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/BooleanEntryReadWriteGenerator.java
@@ -27,7 +27,7 @@ public class BooleanEntryReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         //target.programmingRelated = (parcel.readInt() == 1);
         return parcelParam.invoke(getReadMethod()).eq(JExpr.lit(1));
     }

--- a/parceler/src/main/java/org/parceler/internal/generator/BundleReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/BundleReadWriteGenerator.java
@@ -28,7 +28,7 @@ public class BundleReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         return JExpr.cast(returnJClassRef, parcelParam.invoke(getReadMethod()).arg(parcelableClass.dotclass().invoke("getClassLoader")));
     }
 

--- a/parceler/src/main/java/org/parceler/internal/generator/ConverterWrapperReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ConverterWrapperReadWriteGenerator.java
@@ -31,7 +31,7 @@ public class ConverterWrapperReadWriteGenerator implements ReadWriteGenerator {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         return JExpr._new(converter).invoke(ParcelConverter.CONVERT_FROM_PARCEL).arg(parcelParam);
     }
 

--- a/parceler/src/main/java/org/parceler/internal/generator/EnumReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/EnumReadWriteGenerator.java
@@ -38,7 +38,7 @@ public class EnumReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         JClass enumRef = generationUtil.ref(Enum.class);
         JClass enumClassRef = generationUtil.ref(type);
         JClass stringRef = generationUtil.ref(String.class);

--- a/parceler/src/main/java/org/parceler/internal/generator/LinkParcelReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/LinkParcelReadWriteGenerator.java
@@ -1,0 +1,58 @@
+package org.parceler.internal.generator;
+
+import com.sun.codemodel.*;
+import org.androidtransfuse.adapter.ASTType;
+import org.androidtransfuse.adapter.PackageClass;
+import org.androidtransfuse.gen.ClassGenerationUtil;
+import org.androidtransfuse.gen.ClassNamer;
+import org.androidtransfuse.gen.UniqueVariableNamer;
+import org.parceler.Parcels;
+
+import javax.inject.Inject;
+
+/**
+ * @author John Ericksen
+ */
+public class LinkParcelReadWriteGenerator extends ReadWriteGeneratorBase {
+
+    public static final String WRITE_METHOD = "write";
+    public static final String READ_METHOD = "read";
+    private static final String ANDROID_PARCEL = "android.os.Parcel";
+
+    private final ClassGenerationUtil generationUtil;
+    private final UniqueVariableNamer variableNamer;
+    private final JCodeModel codeModel;
+
+    @Inject
+    public LinkParcelReadWriteGenerator(ClassGenerationUtil generationUtil, UniqueVariableNamer variableNamer, JCodeModel codeModel) {
+        super("readParcelable", new String[]{ClassLoader.class.getName()}, "writeParcelable", new String[]{"android.os.Parcelable", int.class.getName()});
+        this.generationUtil = generationUtil;
+        this.variableNamer = variableNamer;
+        this.codeModel = codeModel;
+    }
+
+    @Override
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+        PackageClass packageClass = ClassNamer.className(type).append(Parcels.IMPL_EXT).build();
+        JType parcelType = generationUtil.ref(ANDROID_PARCEL);
+        JType inputType = generationUtil.ref(type);
+
+        JVar wrapped = body.decl(inputType, variableNamer.generateName(type));
+        JConditional nullCondition = body._if(parcelParam.invoke("readInt").eq(JExpr.lit(-1)));
+        nullCondition._then().assign(wrapped, JExpr._null());
+        nullCondition._else().assign(wrapped, generationUtil.ref(packageClass).staticInvoke(READ_METHOD).arg(parcelParam).arg(readIdentityMap));
+
+        return wrapped;
+    }
+
+    @Override
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
+        PackageClass packageClass = ClassNamer.className(type).append(Parcels.IMPL_EXT).build();
+
+        JConditional nullCondition = body._if(getExpression.eq(JExpr._null()));
+        nullCondition._then().add(parcel.invoke("writeInt").arg(JExpr.lit(-1)));
+        JBlock nonNullCondition = nullCondition._else();
+        nonNullCondition.add(parcel.invoke("writeInt").arg(JExpr.lit(1)));
+        nonNullCondition.add(generationUtil.ref(packageClass).staticInvoke(WRITE_METHOD).arg(getExpression).arg(parcel).arg(flags).arg(writeIdentitySet));
+    }
+}

--- a/parceler/src/main/java/org/parceler/internal/generator/LinkParcelReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/LinkParcelReadWriteGenerator.java
@@ -17,42 +17,28 @@ public class LinkParcelReadWriteGenerator extends ReadWriteGeneratorBase {
 
     public static final String WRITE_METHOD = "write";
     public static final String READ_METHOD = "read";
-    private static final String ANDROID_PARCEL = "android.os.Parcel";
 
     private final ClassGenerationUtil generationUtil;
     private final UniqueVariableNamer variableNamer;
-    private final JCodeModel codeModel;
 
     @Inject
-    public LinkParcelReadWriteGenerator(ClassGenerationUtil generationUtil, UniqueVariableNamer variableNamer, JCodeModel codeModel) {
+    public LinkParcelReadWriteGenerator(ClassGenerationUtil generationUtil, UniqueVariableNamer variableNamer) {
         super("readParcelable", new String[]{ClassLoader.class.getName()}, "writeParcelable", new String[]{"android.os.Parcelable", int.class.getName()});
         this.generationUtil = generationUtil;
         this.variableNamer = variableNamer;
-        this.codeModel = codeModel;
     }
 
     @Override
     public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         PackageClass packageClass = ClassNamer.className(type).append(Parcels.IMPL_EXT).build();
-        JType parcelType = generationUtil.ref(ANDROID_PARCEL);
         JType inputType = generationUtil.ref(type);
-
-        JVar wrapped = body.decl(inputType, variableNamer.generateName(type));
-        JConditional nullCondition = body._if(parcelParam.invoke("readInt").eq(JExpr.lit(-1)));
-        nullCondition._then().assign(wrapped, JExpr._null());
-        nullCondition._else().assign(wrapped, generationUtil.ref(packageClass).staticInvoke(READ_METHOD).arg(parcelParam).arg(readIdentityMap));
-
+        JVar wrapped = body.decl(inputType, variableNamer.generateName(type), generationUtil.ref(packageClass).staticInvoke(READ_METHOD).arg(parcelParam).arg(readIdentityMap));
         return wrapped;
     }
 
     @Override
     public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
         PackageClass packageClass = ClassNamer.className(type).append(Parcels.IMPL_EXT).build();
-
-        JConditional nullCondition = body._if(getExpression.eq(JExpr._null()));
-        nullCondition._then().add(parcel.invoke("writeInt").arg(JExpr.lit(-1)));
-        JBlock nonNullCondition = nullCondition._else();
-        nonNullCondition.add(parcel.invoke("writeInt").arg(JExpr.lit(1)));
-        nonNullCondition.add(generationUtil.ref(packageClass).staticInvoke(WRITE_METHOD).arg(getExpression).arg(parcel).arg(flags).arg(writeIdentitySet));
+        body.add(generationUtil.ref(packageClass).staticInvoke(WRITE_METHOD).arg(getExpression).arg(parcel).arg(flags).arg(writeIdentitySet));
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/LinkParcelReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/LinkParcelReadWriteGenerator.java
@@ -32,7 +32,7 @@ public class LinkParcelReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         PackageClass packageClass = ClassNamer.className(type).append(Parcels.IMPL_EXT).build();
         JType parcelType = generationUtil.ref(ANDROID_PARCEL);
         JType inputType = generationUtil.ref(type);

--- a/parceler/src/main/java/org/parceler/internal/generator/ListReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ListReadWriteGenerator.java
@@ -51,7 +51,7 @@ public class ListReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
 
         JClass arrayListType = generationUtil.ref(listType);
 
@@ -90,7 +90,7 @@ public class ListReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, identity, readIdentityMap);
 
         readLoopBody.invoke(outputVar, "add").arg(readExpression);
 

--- a/parceler/src/main/java/org/parceler/internal/generator/MapReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/MapReadWriteGenerator.java
@@ -52,7 +52,7 @@ public class MapReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
 
         JClass mapImplType = generationUtil.ref(mapType);
 
@@ -98,10 +98,10 @@ public class MapReadWriteGenerator extends ReadWriteGeneratorBase {
         ReadWriteGenerator keyGenerator = generators.getGenerator(keyComponentType);
         ReadWriteGenerator valueGenerator = generators.getGenerator(valueComponentType);
 
-        JExpression readKeyExpression = keyGenerator.generateReader(readLoopBody, parcelParam, keyComponentType, generationUtil.ref(keyComponentType), parcelableClass, readIdentityMap);
+        JExpression readKeyExpression = keyGenerator.generateReader(readLoopBody, parcelParam, keyComponentType, generationUtil.ref(keyComponentType), parcelableClass, identity, readIdentityMap);
         JVar keyVar = readLoopBody.decl(keyType, namer.generateName(keyComponentType), readKeyExpression);
 
-        JExpression readValueExpression = valueGenerator.generateReader(readLoopBody, parcelParam, valueComponentType, generationUtil.ref(valueComponentType), parcelableClass, readIdentityMap);
+        JExpression readValueExpression = valueGenerator.generateReader(readLoopBody, parcelParam, valueComponentType, generationUtil.ref(valueComponentType), parcelableClass, identity, readIdentityMap);
         JVar valueVar = readLoopBody.decl(valueType, namer.generateName(valueComponentType), readValueExpression);
 
         readLoopBody.invoke(outputVar, "put").arg(keyVar).arg(valueVar);

--- a/parceler/src/main/java/org/parceler/internal/generator/NullCheckReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/NullCheckReadWriteGenerator.java
@@ -38,7 +38,7 @@ public abstract class NullCheckReadWriteGenerator implements ReadWriteGenerator 
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
 
         JVar sizeVar = body.decl(codeModel.INT, namer.generateName(codeModel.INT), parcelParam.invoke("readInt"));
 
@@ -52,7 +52,7 @@ public abstract class NullCheckReadWriteGenerator implements ReadWriteGenerator 
 
         JBlock nonNullBody = nullInputConditional._else();
 
-        nonNullBody.assign(value, getGenerator().generateReader(body, parcelParam, type, returnJClassRef, parcelableClass, readIdentityMap));
+        nonNullBody.assign(value, getGenerator().generateReader(body, parcelParam, type, returnJClassRef, parcelableClass, identity, readIdentityMap));
 
         return value;
     }

--- a/parceler/src/main/java/org/parceler/internal/generator/ParcelReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ParcelReadWriteGenerator.java
@@ -50,8 +50,6 @@ public class ParcelReadWriteGenerator extends ReadWriteGeneratorBase {
     @Override
     public JExpression generateReader(JBlock body, JVar parcel, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         JType inputType = generationUtil.ref(type);
-
-        //JVar identity = body.decl(codeModel.INT, variableNamer.generateName("identity"), parcel.invoke("readInt"));
         JVar wrapped = body.decl(inputType, variableNamer.generateName(type));
 
         ParcelableDescriptor parcelDescriptor = this.analysis.analyze(type);

--- a/parceler/src/main/java/org/parceler/internal/generator/ParcelReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ParcelReadWriteGenerator.java
@@ -19,24 +19,17 @@ import com.sun.codemodel.*;
 import org.androidtransfuse.adapter.ASTType;
 import org.androidtransfuse.gen.ClassGenerationUtil;
 import org.androidtransfuse.gen.UniqueVariableNamer;
-import org.parceler.ParcelerRuntimeException;
 import org.parceler.internal.ParcelableAnalysis;
 import org.parceler.internal.ParcelableDescriptor;
 import org.parceler.internal.ParcelableGenerator;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.util.Map;
-import java.util.Set;
 
 /**
 * @author John Ericksen
 */
 public class ParcelReadWriteGenerator extends ReadWriteGeneratorBase {
-
-    public static final String WRITE_METHOD = "write";
-    public static final String READ_METHOD = "read";
-    private static final String ANDROID_PARCEL = "android.os.Parcel";
 
     private final ClassGenerationUtil generationUtil;
     private final ParcelableAnalysis analysis;
@@ -55,82 +48,25 @@ public class ParcelReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcel, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcel, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         JType inputType = generationUtil.ref(type);
-        JType parcelType = generationUtil.ref(ANDROID_PARCEL);
-        //write method
-        JMethod readMethod = findMethodByName(parcelableClass, READ_METHOD);
-        if(readMethod == null){
-            readMethod = parcelableClass.method(JMod.PUBLIC | JMod.STATIC, generationUtil.ref(type), READ_METHOD);
-            JBlock readMethodBody = readMethod.body();
-            JVar readWrapped = readMethodBody.decl(inputType, variableNamer.generateName(type));
-            JVar parcelParam = readMethod.param(parcelType, variableNamer.generateName(parcelType));
-            JVar identityParam = readMethod.param(codeModel.ref(Map.class).narrow(Integer.class, Object.class), variableNamer.generateName("identityMap"));
 
-            JVar identity = readMethodBody.decl(codeModel.INT, variableNamer.generateName("identity"), parcelParam.invoke("readInt"));
-            JBlock containsKeyBody = readMethodBody._if(identityParam.invoke("containsKey").arg(identity))._then();
-            JVar value = containsKeyBody.decl(inputType, variableNamer.generateName(inputType), JExpr.cast(inputType, identityParam.invoke("get").arg(identity)));
-            containsKeyBody._if(value.eq(JExpr._null()))._then()._throw(JExpr._new(generationUtil.ref(ParcelerRuntimeException.class))
-                    .arg("An instance loop was detected whild building Parcelable and deseralization cannot continue.  This error is most likely due to using @ParcelConstructor or @ParcelFactory."));
-            containsKeyBody._return(value);
+        //JVar identity = body.decl(codeModel.INT, variableNamer.generateName("identity"), parcel.invoke("readInt"));
+        JVar wrapped = body.decl(inputType, variableNamer.generateName(type));
 
-            JConditional nullCondition = readMethodBody._if(parcelParam.invoke("readInt").eq(JExpr.lit(-1)));
-            nullCondition._then().assign(readWrapped, JExpr._null());
-
-            ParcelableDescriptor parcelDescriptor = this.analysis.analyze(type);
-            if(parcelDescriptor != null) {
-                generator.get().buildParcelRead(parcelDescriptor, parcelableClass, readWrapped, type, inputType, identity, parcelParam, nullCondition._else(), identityParam);
-            }
-
-            readMethodBody._return(readWrapped);
+        ParcelableDescriptor parcelDescriptor = this.analysis.analyze(type);
+        if(parcelDescriptor != null) {
+            generator.get().buildParcelRead(parcelDescriptor, parcelableClass, wrapped, type, inputType, identity, parcel, body, readIdentityMap);
         }
 
-        JVar wrapped = body.decl(inputType, variableNamer.generateName(type));
-        body.assign(wrapped, JExpr.invoke(readMethod).arg(parcel).arg(readIdentityMap));
         return wrapped;
     }
 
     @Override
     public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
-
-        JType parcelType = generationUtil.ref(ANDROID_PARCEL);
-        //write method
-        JType inputType = generationUtil.ref(type);
-        JMethod writeMethod = findMethodByName(parcelableClass, WRITE_METHOD);
-        if(writeMethod == null){
-            writeMethod = parcelableClass.method(JMod.PUBLIC | JMod.STATIC, Void.TYPE, WRITE_METHOD);
-            JBlock writeMethodBody = writeMethod.body();
-            JVar writeInputVar = writeMethod.param(inputType, variableNamer.generateName(inputType));
-            JVar parcelParam = writeMethod.param(parcelType, variableNamer.generateName(parcelType));
-            JVar flagsParam = writeMethod.param(int.class, variableNamer.generateName("flags"));
-            JVar identityParam = writeMethod.param(codeModel.ref(Set.class).narrow(Integer.class), variableNamer.generateName("identitySet"));
-
-            JVar identity = writeMethodBody.decl(codeModel.INT, variableNamer.generateName("identity"), generationUtil.ref(System.class).staticInvoke("identityHashCode").arg(writeInputVar));
-            writeMethodBody.add(parcelParam.invoke("writeInt").arg(identity));
-
-            JBlock buildBody = writeMethodBody._if(identityParam.invoke("contains").arg(identity).not())._then();
-            buildBody.add(identityParam.invoke("add").arg(identity));
-
-            JConditional nullCondition = buildBody._if(parcelParam.eq(JExpr._null()));
-            nullCondition._then().add(parcelParam.invoke("writeInt").arg(JExpr.lit(-1)));
-            JBlock nonNullCondition = nullCondition._else();
-            nonNullCondition.add(parcelParam.invoke("writeInt").arg(JExpr.lit(1)));
-
-            ParcelableDescriptor parcelDescriptor = this.analysis.analyze(type);
-            if(parcelDescriptor != null) {
-                generator.get().buildParcelWrite(parcelDescriptor, parcelableClass, writeInputVar, type, parcelParam, flagsParam, nonNullCondition, identityParam);
-            }
+        ParcelableDescriptor parcelDescriptor = this.analysis.analyze(type);
+        if(parcelDescriptor != null) {
+            generator.get().buildParcelWrite(parcelDescriptor, parcelableClass, getExpression, type, parcel, flags, body, writeIdentitySet);
         }
-
-        body.invoke(writeMethod).arg(getExpression).arg(parcel).arg(flags).arg(writeIdentitySet);
-    }
-
-    private JMethod findMethodByName(JDefinedClass definedClass, String name){
-        for (JMethod method : definedClass.methods()) {
-            if(method.name().equals(name)){
-                return method;
-            }
-        }
-        return null;
     }
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/ParcelReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ParcelReadWriteGenerator.java
@@ -34,8 +34,8 @@ import java.util.Set;
 */
 public class ParcelReadWriteGenerator extends ReadWriteGeneratorBase {
 
-    private static final String WRITE_METHOD = "write";
-    private static final String READ_METHOD = "read";
+    public static final String WRITE_METHOD = "write";
+    public static final String READ_METHOD = "read";
     private static final String ANDROID_PARCEL = "android.os.Parcel";
 
     private final ClassGenerationUtil generationUtil;
@@ -57,12 +57,11 @@ public class ParcelReadWriteGenerator extends ReadWriteGeneratorBase {
     @Override
     public JExpression generateReader(JBlock body, JVar parcel, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
         JType inputType = generationUtil.ref(type);
-        String readMethodName = READ_METHOD + type.getPackageClass().getFullyQualifiedName().replace(".", "_");
         JType parcelType = generationUtil.ref(ANDROID_PARCEL);
         //write method
-        JMethod readMethod = findMethodByName(parcelableClass, readMethodName);
+        JMethod readMethod = findMethodByName(parcelableClass, READ_METHOD);
         if(readMethod == null){
-            readMethod = parcelableClass.method(JMod.PRIVATE, generationUtil.ref(type), readMethodName);
+            readMethod = parcelableClass.method(JMod.PUBLIC | JMod.STATIC, generationUtil.ref(type), READ_METHOD);
             JBlock readMethodBody = readMethod.body();
             JVar readWrapped = readMethodBody.decl(inputType, variableNamer.generateName(type));
             JVar parcelParam = readMethod.param(parcelType, variableNamer.generateName(parcelType));
@@ -93,13 +92,12 @@ public class ParcelReadWriteGenerator extends ReadWriteGeneratorBase {
     @Override
     public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
 
-        String writeMethodName = WRITE_METHOD + type.getPackageClass().getFullyQualifiedName().replace(".", "_");
         JType parcelType = generationUtil.ref(ANDROID_PARCEL);
         //write method
         JType inputType = generationUtil.ref(type);
-        JMethod writeMethod = findMethodByName(parcelableClass, writeMethodName);
+        JMethod writeMethod = findMethodByName(parcelableClass, WRITE_METHOD);
         if(writeMethod == null){
-            writeMethod = parcelableClass.method(JMod.PRIVATE, Void.TYPE, writeMethodName);
+            writeMethod = parcelableClass.method(JMod.PUBLIC | JMod.STATIC, Void.TYPE, WRITE_METHOD);
             JBlock writeMethodBody = writeMethod.body();
             JVar writeInputVar = writeMethod.param(inputType, variableNamer.generateName(inputType));
             JVar parcelParam = writeMethod.param(parcelType, variableNamer.generateName(parcelType));
@@ -111,8 +109,6 @@ public class ParcelReadWriteGenerator extends ReadWriteGeneratorBase {
 
             JBlock buildBody = writeMethodBody._if(identityParam.invoke("contains").arg(identity).not())._then();
             buildBody.add(identityParam.invoke("add").arg(identity));
-
-            //body.decl(codeModel.INT, "identity", generationUtil.ref(System.class).staticInvoke("identityHashCode").arg())
 
             ParcelableDescriptor parcelDescriptor = this.analysis.analyze(type);
             if(parcelDescriptor != null) {

--- a/parceler/src/main/java/org/parceler/internal/generator/ParcelableReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ParcelableReadWriteGenerator.java
@@ -28,7 +28,7 @@ public class ParcelableReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         return JExpr.cast(returnJClassRef, parcelParam.invoke(getReadMethod()).arg(parcelableClass.dotclass().invoke("getClassLoader")));
     }
 

--- a/parceler/src/main/java/org/parceler/internal/generator/ReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/ReadWriteGenerator.java
@@ -23,7 +23,7 @@ import org.androidtransfuse.adapter.ASTType;
 */
 public interface ReadWriteGenerator {
 
-    JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap);
+    JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap);
 
     void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet);
 }

--- a/parceler/src/main/java/org/parceler/internal/generator/SerializableReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SerializableReadWriteGenerator.java
@@ -30,7 +30,7 @@ public class SerializableReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         return JExpr.cast(returnJClassRef, parcelParam.invoke(getReadMethod()));
     }
 

--- a/parceler/src/main/java/org/parceler/internal/generator/SetReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SetReadWriteGenerator.java
@@ -52,7 +52,7 @@ public class SetReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
 
         JClass setImplType = generationUtil.ref(setType);
 
@@ -89,7 +89,7 @@ public class SetReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, identity, readIdentityMap);
 
         readLoopBody.invoke(outputVar, "add").arg(readExpression);
 

--- a/parceler/src/main/java/org/parceler/internal/generator/SimpleReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SimpleReadWriteGenerator.java
@@ -28,7 +28,7 @@ public class SimpleReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         return parcelParam.invoke(getReadMethod());
     }
 

--- a/parceler/src/main/java/org/parceler/internal/generator/SingleEntryArrayReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SingleEntryArrayReadWriteGenerator.java
@@ -35,7 +35,7 @@ public class SingleEntryArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
         return JExpr.component(parcelParam.invoke(getReadMethod()), JExpr.lit(0));
     }
 

--- a/parceler/src/main/java/org/parceler/internal/generator/SparseArrayReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/SparseArrayReadWriteGenerator.java
@@ -47,7 +47,7 @@ public class SparseArrayReadWriteGenerator extends ReadWriteGeneratorBase {
     }
 
     @Override
-    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar readIdentityMap) {
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
 
         JClass sparseArrayType = generationUtil.ref("android.util.SparseArray");
 
@@ -82,7 +82,7 @@ public class SparseArrayReadWriteGenerator extends ReadWriteGeneratorBase {
 
         ReadWriteGenerator generator = generators.getGenerator(componentType);
 
-        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, readIdentityMap);
+        JExpression readExpression = generator.generateReader(readLoopBody, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, identity, readIdentityMap);
 
         readLoopBody.invoke(outputVar, "append").arg(keyVar).arg(readExpression);
 

--- a/parceler/src/test/java/org/parceler/internal/ParcelableGeneratorTest.java
+++ b/parceler/src/test/java/org/parceler/internal/ParcelableGeneratorTest.java
@@ -34,8 +34,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import javax.inject.Inject;
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -73,7 +71,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testFieldSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testFieldSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         descriptor.getFieldPairs().add(
@@ -85,7 +83,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testFieldConverterSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testFieldConverterSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         descriptor.getFieldPairs().add(
@@ -97,7 +95,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testMethodSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testMethodSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         ASTMethod getter = getMethod("getValue", targetType.getMethods());
@@ -113,7 +111,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testMethodConverterSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testMethodConverterSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         ASTMethod getter = getMethod("getValue", targetType.getMethods());
@@ -129,7 +127,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testConstructorFieldSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testConstructorFieldSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         ASTType stringType = astClassFactory.getType(String.class);
@@ -147,7 +145,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testConstructorFieldConverterSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testConstructorFieldConverterSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         ASTType stringType = astClassFactory.getType(String.class);
@@ -167,7 +165,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testConstructorMethodSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testConstructorMethodSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         ASTMethod getter = getMethod("getValue", targetType.getMethods());
@@ -186,7 +184,7 @@ public class ParcelableGeneratorTest {
     }
 
     @Test
-    public void testConstructorMethodConverterSerialization() throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    public void testConstructorMethodConverterSerialization() throws Exception {
         ParcelableDescriptor descriptor = new ParcelableDescriptor();
 
         ASTMethod getter = getMethod("getValue", targetType.getMethods());
@@ -239,7 +237,7 @@ public class ParcelableGeneratorTest {
         return null;
     }
 
-    private void testSerialization(ParcelableDescriptor descriptor) throws IOException, ClassNotFoundException, NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+    private void testSerialization(ParcelableDescriptor descriptor) throws Exception {
         JDefinedClass targetGenerated = generator.generateParcelable(targetType, descriptor);
 
         ClassLoader classLoader = codeGenerationUtil.build();
@@ -251,7 +249,7 @@ public class ParcelableGeneratorTest {
 
         parcel.setDataPosition(0);
 
-        Parcelable inputParcelable = parcelableClass.getConstructor(Parcel.class).newInstance(parcel);
+        Parcelable inputParcelable = ((Parcelable.Creator<Parcelable>)parcelableClass.getField("CREATOR").get(null)).createFromParcel(parcel);
 
         Target wrapped = Parcels.unwrap(inputParcelable);
 

--- a/parceler/src/test/java/org/parceler/internal/ParcelableIntegrationTest.java
+++ b/parceler/src/test/java/org/parceler/internal/ParcelableIntegrationTest.java
@@ -93,7 +93,7 @@ public class ParcelableIntegrationTest {
     }
 
     @Test
-    public void testGeneratedParcelable() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+    public void testGeneratedParcelable() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException, NoSuchFieldException {
 
         ParcelTarget parcelTarget = new ParcelTarget();
         ParcelSecondTarget parcelSecondTarget = new ParcelSecondTarget();
@@ -109,7 +109,7 @@ public class ParcelableIntegrationTest {
         outputParcelable.writeToParcel(parcel, 0);
         parcel.setDataPosition(0);
 
-        Parcelable inputParcelable = parcelableClass.getConstructor(Parcel.class).newInstance(parcel);
+        Parcelable inputParcelable = ((Parcelable.Creator<Parcelable>)parcelableClass.getField("CREATOR").get(null)).createFromParcel(parcel);
 
         ParcelTarget wrapped = Parcels.unwrap(inputParcelable);
 

--- a/parceler/src/test/java/org/parceler/internal/TestParcelerModule.java
+++ b/parceler/src/test/java/org/parceler/internal/TestParcelerModule.java
@@ -34,10 +34,7 @@ import org.androidtransfuse.util.Logger;
 import org.androidtransfuse.validation.Validator;
 import org.parceler.Generated;
 import org.parceler.ParcelAnnotationProcessor;
-import org.parceler.internal.generator.EnumReadWriteGenerator;
-import org.parceler.internal.generator.NullCheckFactory;
-import org.parceler.internal.generator.ParcelReadWriteGenerator;
-import org.parceler.internal.generator.SerializableReadWriteGenerator;
+import org.parceler.internal.generator.*;
 
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.Messager;
@@ -100,7 +97,7 @@ public class TestParcelerModule {
                                     JCodeModel codeModel,
                                     SerializableReadWriteGenerator serializableReadWriteGenerator,
                                     NullCheckFactory nullCheckFactory,
-                                    ParcelReadWriteGenerator parcelReadWriteGenerator,
+                                    LinkParcelReadWriteGenerator parcelReadWriteGenerator,
                                     EnumReadWriteGenerator enumReadWriteGenerator){
 
         return ParcelerModule.addGenerators(new Generators(astClassFactory), astClassFactory, generationUtil, externalParcelRepository, namer, codeModel, serializableReadWriteGenerator, nullCheckFactory, parcelReadWriteGenerator, enumReadWriteGenerator);


### PR DESCRIPTION
This PR adds static `read()` and `write()` methods to the generated Parcelable in an effort to reduce the number of methods added by Parceler (See #157).  Previously, each bean's read and write methods were duplicated across each bean that contained them in their object graph.  With this change, each `read()` and `write()` method is owned by the given generated `Parcelable` and referenced on demand.  This should keep the number of methods added to a linear 8 methods per annotated class.

Example:
```java
@Parcel
public class A {
    String name;
    B b;
}
@Parcel
public class B {
    String name;
}

```
Generates:
```java

public class A$$Parcelable
    implements Parcelable, ParcelWrapper<org.parceler.A>
{

    private org.parceler.A a$$0;
    @SuppressWarnings("UnusedDeclaration")
    public final static A$$Parcelable.Creator$$9 CREATOR = new A$$Parcelable.Creator$$9();

    public A$$Parcelable(org.parceler.A a$$2) {
        a$$0 = a$$2;
    }

    @Override
    public void writeToParcel(android.os.Parcel parcel$$0, int flags) {
        write(a$$0, parcel$$0, flags, new HashSet<Integer>());
    }

    public static void write(org.parceler.A a$$1, android.os.Parcel parcel$$1, int flags$$0, Set<Integer> identitySet$$0) {
        int identity$$0 = System.identityHashCode(a$$1);
        parcel$$1 .writeInt(identity$$0);
        if (!identitySet$$0 .contains(identity$$0)) {
            identitySet$$0 .add(identity$$0);
            if (a$$1 == null) {
                parcel$$1 .writeInt(-1);
            } else {
                parcel$$1 .writeInt(1);
                org.parceler.B$$Parcelable.write(a$$1 .b, parcel$$1, flags$$0, identitySet$$0);
                parcel$$1 .writeString(a$$1 .name);
            }
        }
    }

    @Override
    public int describeContents() {
        return  0;
    }

    @Override
    public org.parceler.A getParcel() {
        return a$$0;
    }

    public static org.parceler.A read(android.os.Parcel parcel$$3, Map<Integer, Object> identityMap$$0) {
        org.parceler.A a$$3;
        int identity$$1 = parcel$$3 .readInt();
        if (identityMap$$0 .containsKey(identity$$1)) {
            org.parceler.A a$$4 = ((org.parceler.A) identityMap$$0 .get(identity$$1));
            if (a$$4 == null) {
                throw new ParcelerRuntimeException("An instance loop was detected whild building Parcelable and deseralization cannot continue.  This error is most likely due to using @ParcelConstructor or @ParcelFactory.");
            }
            return a$$4;
        }
        if (parcel$$3 .readInt() == -1) {
            a$$3 = null;
        } else {
            org.parceler.A a$$5;
            identityMap$$0 .put(identity$$1, null);
            a$$5 = new org.parceler.A();
            identityMap$$0 .put(identity$$1, a$$5);
            B b$$0 = org.parceler.B$$Parcelable.read(parcel$$3, identityMap$$0);
            a$$5 .b = b$$0;
            a$$5 .name = parcel$$3 .readString();
            a$$3 = a$$5;
        }
        return a$$3;
    }

    public final static class Creator$$9
        implements Creator<A$$Parcelable>
    {

        @Override
        public A$$Parcelable createFromParcel(android.os.Parcel parcel$$2) {
            return new A$$Parcelable(read(parcel$$2, new HashMap<Integer, Object>()));
        }

        @Override
        public A$$Parcelable[] newArray(int size) {
            return new A$$Parcelable[size] ;
        }
    }
}

public class B$$Parcelable
    implements Parcelable, ParcelWrapper<org.parceler.B>
{

    private org.parceler.B b$$0;
    @SuppressWarnings("UnusedDeclaration")
    public final static B$$Parcelable.Creator$$7 CREATOR = new B$$Parcelable.Creator$$7();

    public B$$Parcelable(org.parceler.B b$$2) {
        b$$0 = b$$2;
    }

    @Override
    public void writeToParcel(android.os.Parcel parcel$$0, int flags) {
        write(b$$0, parcel$$0, flags, new HashSet<Integer>());
    }

    public static void write(org.parceler.B b$$1, android.os.Parcel parcel$$1, int flags$$0, Set<Integer> identitySet$$0) {
        int identity$$0 = System.identityHashCode(b$$1);
        parcel$$1 .writeInt(identity$$0);
        if (!identitySet$$0 .contains(identity$$0)) {
            identitySet$$0 .add(identity$$0);
            if (b$$1 == null) {
                parcel$$1 .writeInt(-1);
            } else {
                parcel$$1 .writeInt(1);
                parcel$$1 .writeString(b$$1 .name);
            }
        }
    }

    @Override
    public int describeContents() {
        return  0;
    }

    @Override
    public org.parceler.B getParcel() {
        return b$$0;
    }

    public static org.parceler.B read(android.os.Parcel parcel$$3, Map<Integer, Object> identityMap$$0) {
        org.parceler.B b$$3;
        int identity$$1 = parcel$$3 .readInt();
        if (identityMap$$0 .containsKey(identity$$1)) {
            org.parceler.B b$$4 = ((org.parceler.B) identityMap$$0 .get(identity$$1));
            if (b$$4 == null) {
                throw new ParcelerRuntimeException("An instance loop was detected whild building Parcelable and deseralization cannot continue.  This error is most likely due to using @ParcelConstructor or @ParcelFactory.");
            }
            return b$$4;
        }
        if (parcel$$3 .readInt() == -1) {
            b$$3 = null;
        } else {
            org.parceler.B b$$5;
            identityMap$$0 .put(identity$$1, null);
            b$$5 = new org.parceler.B();
            identityMap$$0 .put(identity$$1, b$$5);
            b$$5 .name = parcel$$3 .readString();
            b$$3 = b$$5;
        }
        return b$$3;
    }

    public final static class Creator$$7
        implements Creator<B$$Parcelable>
    {

        @Override
        public B$$Parcelable createFromParcel(android.os.Parcel parcel$$2) {
            return new B$$Parcelable(read(parcel$$2, new HashMap<Integer, Object>()));
        }

        @Override
        public B$$Parcelable[] newArray(int size) {
            return new B$$Parcelable[size] ;
        }
    }
}

```