### PR TITLE
Add support for MutableLiveData<T>

### DIFF
--- a/examples/test/src/test/java/android/arch/lifecycle/MutableLiveData.java
+++ b/examples/test/src/test/java/android/arch/lifecycle/MutableLiveData.java
@@ -1,0 +1,21 @@
+package android.arch.lifecycle;
+
+public class MutableLiveData<T> {
+
+    private T value;
+
+    public T getValue() {
+        return value;
+    }
+
+    public MutableLiveData() {
+    }
+
+    public void setValue(T value) {
+        this.value = value;
+    }
+
+    public void postValue(T value) {
+        this.value = value;
+    }
+}

--- a/examples/test/src/test/java/org/parceler/MutableLiveDataTest.java
+++ b/examples/test/src/test/java/org/parceler/MutableLiveDataTest.java
@@ -1,0 +1,40 @@
+package org.parceler;
+
+import android.arch.lifecycle.MutableLiveData;
+import android.os.Parcelable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class MutableLiveDataTest {
+
+    @Parcel
+    public static class TestTarget {
+        MutableLiveData<TestParcel> test = new MutableLiveData<TestParcel>();
+    }
+
+    @Parcel
+    public static class TestParcel {
+        String value;
+    }
+
+    @Test
+    public void testMutableLiveData() {
+
+        TestParcel parcel = new TestParcel();
+        parcel.value = "test";
+        TestTarget target = new TestTarget();
+        target.test.setValue(parcel);
+
+        Parcelable wrap = ParcelsTestUtil.wrap(target);
+        TestTarget unwrap = Parcels.unwrap(wrap);
+        assertNotNull(unwrap.test.getValue());
+        assertEquals("test", unwrap.test.getValue().value);
+    }
+}

--- a/parceler/src/main/java/org/parceler/internal/ParcelerModule.java
+++ b/parceler/src/main/java/org/parceler/internal/ParcelerModule.java
@@ -206,6 +206,7 @@ public class ParcelerModule {
         generators.addPair("android.os.IBinder", "readStrongBinder", "writeStrongBinder");
         generators.add(Matchers.type(new ASTStringType("android.os.Bundle")).ignoreGenerics().build(), new BundleReadWriteGenerator("readBundle", "writeBundle", "android.os.Bundle"));
         generators.add(new ObservableFieldMatcher(generators), nullCheckFactory.get(new ObservableFieldReadWriteGenerator(generators, generationUtil)));
+        generators.add(new MutableLiveDataMatcher(generators), nullCheckFactory.get(new MutableLiveDataReadWriteGenerator(generators, generationUtil, namer)));
         generators.addPair("android.util.SparseBooleanArray", "readSparseBooleanArray", "writeSparseBooleanArray");
         generators.add(Matchers.type(new ASTStringType("android.util.SparseArray")).ignoreGenerics().build(), new SparseArrayReadWriteGenerator(generationUtil, namer, generators, astClassFactory, codeModel));
         generators.add(new InheritsMatcher(new ASTStringType("android.os.Parcelable")), new ParcelableReadWriteGenerator("readParcelable", "writeParcelable", "android.os.Parcelable"));

--- a/parceler/src/main/java/org/parceler/internal/generator/MutableLiveDataReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/MutableLiveDataReadWriteGenerator.java
@@ -1,0 +1,57 @@
+package org.parceler.internal.generator;
+
+import com.sun.codemodel.*;
+import org.androidtransfuse.adapter.ASTStringType;
+import org.androidtransfuse.adapter.ASTType;
+import org.androidtransfuse.gen.ClassGenerationUtil;
+import org.androidtransfuse.gen.UniqueVariableNamer;
+import org.parceler.internal.Generators;
+
+import javax.inject.Inject;
+
+public class MutableLiveDataReadWriteGenerator extends ReadWriteGeneratorBase {
+
+    private static final ASTType TYPE = new ASTStringType("android.arch.lifecycle.MutableLiveData");
+
+    private final Generators generators;
+    private final ClassGenerationUtil generationUtil;
+    private final UniqueVariableNamer namer;
+
+    @Inject
+    public MutableLiveDataReadWriteGenerator(Generators generators, ClassGenerationUtil generationUtil, UniqueVariableNamer namer) {
+        super("readParcelable", new String[]{ClassLoader.class.getName()}, "writeParcelable", new String[]{"android.os.Parcelable", int.class.getName()});
+        this.generators = generators;
+        this.generationUtil = generationUtil;
+        this.namer = namer;
+    }
+
+    @Override
+    public JExpression generateReader(JBlock body, JVar parcelParam, ASTType type, JClass returnJClassRef, JDefinedClass parcelableClass, JVar identity, JVar readIdentityMap) {
+
+        ASTType componentType = type.getGenericArgumentTypes().get(0);
+
+        ReadWriteGenerator generator = generators.getGenerator(componentType);
+
+        JExpression readExpression = generator.generateReader(body, parcelParam, componentType, generationUtil.ref(componentType), parcelableClass, identity, readIdentityMap);
+
+        JClass mutableLiveDataType = generationUtil.ref(TYPE);
+
+        JVar outputVar = body.decl(mutableLiveDataType, namer.generateName(mutableLiveDataType));
+
+        body.assign(outputVar, JExpr._new(generationUtil.ref(TYPE)));
+
+        body.invoke(outputVar, "setValue").arg(readExpression);
+
+        return outputVar;
+    }
+
+    @Override
+    public void generateWriter(JBlock body, JExpression parcel, JVar flags, ASTType type, JExpression getExpression, JDefinedClass parcelableClass, JVar writeIdentitySet) {
+
+        ASTType componentType = type.getGenericArgumentTypes().get(0);
+
+        ReadWriteGenerator generator = generators.getGenerator(componentType);
+
+        generator.generateWriter(body, parcel, flags, componentType, getExpression.invoke("getValue"), parcelableClass, writeIdentitySet);
+    }
+}

--- a/parceler/src/main/java/org/parceler/internal/generator/MutableLiveDataReadWriteGenerator.java
+++ b/parceler/src/main/java/org/parceler/internal/generator/MutableLiveDataReadWriteGenerator.java
@@ -38,7 +38,7 @@ public class MutableLiveDataReadWriteGenerator extends ReadWriteGeneratorBase {
 
         JVar outputVar = body.decl(mutableLiveDataType, namer.generateName(mutableLiveDataType));
 
-        body.assign(outputVar, JExpr._new(generationUtil.ref(TYPE)));
+        body.assign(outputVar, JExpr._new(mutableLiveDataType));
 
         body.invoke(outputVar, "setValue").arg(readExpression);
 

--- a/parceler/src/main/java/org/parceler/internal/matcher/MutableLiveDataMatcher.java
+++ b/parceler/src/main/java/org/parceler/internal/matcher/MutableLiveDataMatcher.java
@@ -1,0 +1,31 @@
+package org.parceler.internal.matcher;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import org.androidtransfuse.adapter.ASTStringType;
+import org.androidtransfuse.adapter.ASTType;
+import org.androidtransfuse.util.matcher.Matcher;
+import org.androidtransfuse.util.matcher.Matchers;
+import org.parceler.internal.Generators;
+
+public class MutableLiveDataMatcher implements Matcher<ASTType> {
+
+    private static final Matcher<ASTType> MATCHER = Matchers.type(new ASTStringType("android.arch.lifecycle.MutableLiveData")).ignoreGenerics().build();
+
+    private final Generators generators;
+
+    public MutableLiveDataMatcher(Generators generators) {
+        this.generators = generators;
+    }
+
+    @Override
+    public boolean matches(ASTType input) {
+        return MATCHER.matches(input) &&
+                input.getGenericArgumentTypes().size() == 1 &&
+                FluentIterable.from(input.getGenericArgumentTypes()).allMatch(new Predicate<ASTType>() {
+                    public boolean apply(ASTType astType) {
+                        return generators.matches(astType);
+                    }
+                });
+    }
+}


### PR DESCRIPTION
Add support for parceling MutableLiveData

Similar to the implementation for ObservableField, except the value has to be set through setValue() instead of the constructor.
Add test for wrap and unwrap.

https://developer.android.com/reference/android/arch/lifecycle/MutableLiveData.html